### PR TITLE
Added customizable minimum length before performing the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ There are no filter and limit action inside the component. So, do it in your API
 ##### `param` : name of the search query in Ajax call. default ( q )
 <br/>
 
+##### `min` : Minimum input typed chars before performing the search query. default ( 3 )
+<br/>
+
 ##### `limit` : amount of query limit in ajax call.
 example, `limit=5` the AJAX URL will be `http://some-url.com/API/list?q=blabla&limit=5`
 

--- a/vue-autocomplete.vue
+++ b/vue-autocomplete.vue
@@ -150,7 +150,7 @@
       // minimum length
       min: {
         type: String,
-        default: 3
+        default: 0
       },
 
       // add 'limit' query to AJAX URL will be fetched

--- a/vue-autocomplete.vue
+++ b/vue-autocomplete.vue
@@ -149,7 +149,7 @@
 
       // minimum length
       min: {
-        type: Number,
+        type: String,
         default: 3
       },
 

--- a/vue-autocomplete.vue
+++ b/vue-autocomplete.vue
@@ -147,6 +147,12 @@
         default: 'q'
       },
 
+      // minimum length
+      min: {
+        type: Number,
+        default: 3
+      },
+
       // add 'limit' query to AJAX URL will be fetched
       limit: {
         type: String,
@@ -291,6 +297,8 @@
 
       getData(val){
         let self = this;
+
+        if (val.length < this.min) return;
 
         if(this.url != null){
 


### PR DESCRIPTION
I needed this feature to limit server queries. I see I'm not the only one, this PR fixes https://github.com/BosNaufal/vue-autocomplete/issues/7 needs.
