### PR TITLE
Mobile browsers - fix

### DIFF
--- a/vue-autocomplete.vue
+++ b/vue-autocomplete.vue
@@ -78,7 +78,6 @@
           :class="class"
           :name="name"
           :placeholder="placeholder"
-          v-model="type"
           @input="input(type)"
           @dblclick="showAll"
           @blur="hideAll"
@@ -194,6 +193,9 @@
 
       input(val){
         this.showList = true;
+        
+        //You can not use v-model with some mobile browsers.
+        this.type = val;
 
         // Callback Event
         this.$dispatch('autocomplete:input',this.$get('name'),val);


### PR DESCRIPTION
You can not use v-model for some mobile browsers (like Chrome for android) in this case.
I've spent a few hours before solving this. I've found that you couldn't type in the input when using mobile browsers with virtual keyboard - simply after typing one letter input was cleared instantly.

It looks like there's some problem with emitting an event in Vue. 

More info:

https://github.com/vuejs/vue/issues/9299